### PR TITLE
Ignore extension elements in launch variables

### DIFF
--- a/src/content/launcher/sync-frame.ts
+++ b/src/content/launcher/sync-frame.ts
@@ -2,11 +2,16 @@ import { RootUrl } from '../../shared/constants';
 import { Frame } from '../../shared/services/frame';
 import { frame } from '../../shared/services/messaging';
 import { storage } from '../../shared/services/storage';
+import { createElementId } from '../../shared/utils/dom';
 
 export class SyncFrame extends Frame {
+  static readonly ElementId = {
+    FRAME: createElementId('LauncherSync'),
+  };
+
   constructor() {
     super({
-      id: 'sync-frame',
+      id: SyncFrame.ElementId.FRAME,
       src: `${RootUrl}/_extension/launcher?__displayContext=extension`,
       hidden: true,
     });
@@ -21,7 +26,7 @@ export class SyncFrame extends Frame {
       const token = await storage.get('AUTH_TOKEN');
       const organizationId = await storage.get('SELECTED_ORGANIZATION');
       if (token && organizationId) {
-        frame.send('sync-frame', 'auth/token_changed', {
+        frame.send(SyncFrame.ElementId.FRAME, 'auth/token_changed', {
           authToken: token,
           organizationId,
         });
@@ -53,7 +58,7 @@ export class SyncFrame extends Frame {
     const token = await storage.get('AUTH_TOKEN');
     const organizationId = await storage.get('SELECTED_ORGANIZATION');
     if (token && organizationId && this.isReady()) {
-      frame.send('sync-frame', 'auth/token_changed', {
+      frame.send(SyncFrame.ElementId.FRAME, 'auth/token_changed', {
         authToken: token,
         organizationId,
       });

--- a/src/content/launcher/ui/collapse.ts
+++ b/src/content/launcher/ui/collapse.ts
@@ -1,4 +1,10 @@
+import { createElementId } from '../../../shared/utils/dom';
+
 export class CollapseButton {
+  static readonly ElementId = {
+    BUTTON: createElementId('LauncherCollapseButton'),
+  };
+
   private button: HTMLElement;
 
   constructor(onClickHandler: () => void) {
@@ -7,6 +13,7 @@ export class CollapseButton {
 
   private createButton(onClickHandler: () => void): HTMLElement {
     const button = document.createElement('button');
+    button.id = CollapseButton.ElementId.BUTTON;
     button.style.cssText = `
       display: flex;
       align-items: center;

--- a/src/content/launcher/ui/container.ts
+++ b/src/content/launcher/ui/container.ts
@@ -1,11 +1,14 @@
-import {
-  ElementIds,
-  FrameDimensions,
-  ZIndexes,
-} from '../../../shared/constants';
+import { FrameDimensions, ZIndexes } from '../../../shared/constants';
+import { createElementId } from '../../../shared/utils/dom';
 import { Tooltip } from './tooltip';
 
 export class LauncherContainer {
+  static readonly ElementId = {
+    CONTAINER: createElementId('Launcher'),
+    INNER: createElementId('LauncherInner'),
+    APPS_CONTAINER: createElementId('LauncherAppsContainer'),
+  };
+
   private element: HTMLElement;
   private appsContainer: HTMLElement;
   private settingsTooltip: Tooltip;
@@ -21,7 +24,7 @@ export class LauncherContainer {
 
   private createLauncherElement(): HTMLElement {
     const launcher = document.createElement('div');
-    launcher.id = ElementIds.LAUNCHER;
+    launcher.id = LauncherContainer.ElementId.CONTAINER;
     launcher.style.cssText = `
       position: fixed;
       bottom: 128px;
@@ -33,6 +36,7 @@ export class LauncherContainer {
     `;
 
     const inner = document.createElement('div');
+    inner.id = LauncherContainer.ElementId.INNER;
     inner.style.cssText = `
       margin-left: auto;
       width: 48px;
@@ -58,6 +62,7 @@ export class LauncherContainer {
 
   private createAppsContainer(): HTMLElement {
     const container = document.createElement('div');
+    container.id = LauncherContainer.ElementId.APPS_CONTAINER;
     container.className = 'apps-container';
     container.style.cssText = `
       display: flex;

--- a/src/content/launcher/ui/logo.ts
+++ b/src/content/launcher/ui/logo.ts
@@ -1,4 +1,10 @@
+import { createElementId } from '../../../shared/utils/dom';
+
 export class Logo {
+  static readonly ElementId = {
+    LOGO: createElementId('LauncherLogo'),
+  };
+
   private element: HTMLElement;
 
   constructor() {
@@ -17,6 +23,7 @@ export class Logo {
 
   private createLogoElement(): HTMLElement {
     const logo = document.createElement('div');
+    logo.id = Logo.ElementId.LOGO;
     logo.innerHTML = this.createLogoSvg();
     logo.style.cssText = `
       padding: 8px 0;

--- a/src/content/launcher/ui/tooltip.ts
+++ b/src/content/launcher/ui/tooltip.ts
@@ -1,4 +1,5 @@
 import { ZIndexes } from '../../../shared/constants';
+import { createElementId } from '../../../shared/utils/dom';
 
 export interface TooltipOptions {
   text: string;
@@ -6,6 +7,10 @@ export interface TooltipOptions {
 }
 
 export class Tooltip {
+  static readonly ElementId = {
+    TOOLTIP: createElementId('LauncherTooltip'),
+  };
+
   private element: HTMLElement;
 
   constructor(options: TooltipOptions) {
@@ -17,6 +22,7 @@ export class Tooltip {
     rightOffset = 48,
   }: TooltipOptions): HTMLElement {
     const tooltip = document.createElement('div');
+    tooltip.id = Tooltip.ElementId.TOOLTIP;
     tooltip.style.cssText = `
       opacity: 0;
       display: flex;

--- a/src/content/page-utils.ts
+++ b/src/content/page-utils.ts
@@ -1,3 +1,5 @@
+import { isMindStudioElement } from '../shared/utils/dom';
+
 /**
  * Utilities for interacting with the current web page.
  * These utilities only work in the content script context.
@@ -50,6 +52,13 @@ export const pageUtils = {
 function cleanNode(node: Node): void {
   if (node.nodeType === Node.ELEMENT_NODE) {
     const el = node as HTMLElement;
+
+    // Remove MindStudio elements
+    if (isMindStudioElement(el.id)) {
+      el.remove();
+      return;
+    }
+
     const tagsToRemove = ['script', 'iframe', 'svg'];
     if (tagsToRemove.includes(el.tagName.toLowerCase())) {
       el.remove();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,14 +13,7 @@ export const ZIndexes = {
   AUTH: 999998,
 } as const;
 
-export const ElementIds = {
-  FLOATING_BUTTON: '__MindStudioFloatingButton',
-  LAUNCHER: '__MindStudioLauncher',
-  PLAYER: '__MindStudioPlayer',
-  AUTH: '__MindStudioAuth',
-  CONTENT_WRAPPER: '__MindStudioContentWrapper',
-  LAUNCHER_SYNC: '__MindStudioLauncherSync',
-} as const;
+export const MINDSTUDIO_ID_PREFIX = '__MindStudioExtension_';
 
 // Add frame dimensions
 export const FrameDimensions = {

--- a/src/shared/services/frame.ts
+++ b/src/shared/services/frame.ts
@@ -5,7 +5,7 @@ export interface FrameOptions {
   hidden?: boolean;
 }
 
-export class Frame {
+export abstract class Frame {
   protected element: HTMLIFrameElement;
   protected isLoaded = false;
 

--- a/src/shared/utils/dom.ts
+++ b/src/shared/utils/dom.ts
@@ -1,0 +1,22 @@
+import { MINDSTUDIO_ID_PREFIX } from '../constants';
+
+/**
+ * Creates a MindStudio element ID with the standard prefix
+ * @param id The unique identifier for the element
+ * @returns A prefixed element ID
+ */
+export function createElementId(id: string): string {
+  return `${MINDSTUDIO_ID_PREFIX}${id}`;
+}
+
+/**
+ * Checks if an element ID belongs to MindStudio
+ * @param id The element ID to check
+ * @returns True if the ID starts with the MindStudio prefix
+ */
+export function isMindStudioElement(id: string | null): boolean {
+  if (!id) {
+    return false;
+  }
+  return id.startsWith(MINDSTUDIO_ID_PREFIX);
+}

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -22,12 +22,6 @@
         top: 0;
         left: 0;
       }
-      #player-frame {
-        width: 100%;
-        height: 100%;
-        border: none;
-        overflow: hidden;
-      }
     </style>
   </head>
   <body>

--- a/src/sidepanel/player-frame.ts
+++ b/src/sidepanel/player-frame.ts
@@ -3,17 +3,30 @@ import { WorkerLaunchPayload } from '../shared/types/events';
 import { Frame } from '../shared/services/frame';
 import { frame, runtime } from '../shared/services/messaging';
 import { storage } from '../shared/services/storage';
+import { createElementId } from '../shared/utils/dom';
 
 export class PlayerFrame extends Frame {
+  static readonly ElementId = {
+    FRAME: createElementId('PlayerFrame'),
+  };
+
   private pendingWorker: WorkerLaunchPayload | null = null;
   private isFirstLoad = true;
 
   constructor(container: HTMLElement) {
     super({
-      id: 'player-frame',
+      id: PlayerFrame.ElementId.FRAME,
       src: `${RootUrl}/_extension/player?__displayContext=extension&__controlledAuth=1`,
       container,
     });
+
+    // Add frame styles
+    this.element.style.cssText = `
+      width: 100%;
+      height: 100%;
+      border: none;
+      overflow: hidden;
+    `;
 
     this.setupEventListeners();
   }
@@ -27,7 +40,7 @@ export class PlayerFrame extends Frame {
       const token = await storage.get('AUTH_TOKEN');
       const organizationId = await storage.get('SELECTED_ORGANIZATION');
       if (token && organizationId) {
-        frame.send('player-frame', 'auth/token_changed', {
+        frame.send(PlayerFrame.ElementId.FRAME, 'auth/token_changed', {
           authToken: token,
           organizationId,
         });
@@ -50,7 +63,7 @@ export class PlayerFrame extends Frame {
     storage.onChange('AUTH_TOKEN', async (token) => {
       const organizationId = await storage.get('SELECTED_ORGANIZATION');
       if (organizationId && token && this.isReady()) {
-        frame.send('player-frame', 'auth/token_changed', {
+        frame.send(PlayerFrame.ElementId.FRAME, 'auth/token_changed', {
           authToken: token,
           organizationId,
         });
@@ -76,7 +89,7 @@ export class PlayerFrame extends Frame {
       return;
     }
 
-    frame.send('player-frame', 'player/load_worker', {
+    frame.send(PlayerFrame.ElementId.FRAME, 'player/load_worker', {
       id: payload.appId,
       name: payload.appName,
       iconUrl: payload.appIcon,


### PR DESCRIPTION
We don't want to pass injected UI into the laucnh variables. 

This standardizes IDs and removes then when scraping the DOM