### PR TITLE
Tabbed side panel

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -44,15 +44,19 @@ class BackgroundService {
         }
 
         try {
-          // Store worker details
           this.pendingWorker = payload;
+
           console.info('[MindStudio][Background] Launching worker:', {
             appId: payload.appId,
             appName: payload.appName,
             tabId: sender.tab.id,
           });
 
-          // Open side panel
+          // Set tab-specific panel and open it
+          chrome.sidePanel.setOptions({
+            tabId: sender.tab.id,
+            path: 'worker-panel.html?type=worker',
+          });
           await chrome.sidePanel.open({ tabId: sender.tab.id });
 
           // If sidepanel is ready, send init event immediately

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,7 +1,7 @@
 import { THANK_YOU_PAGE } from '../shared/constants';
-import { WorkerLaunchPayload } from '../shared/types/events';
 import { runtime } from '../shared/services/messaging';
 import { storage } from '../shared/services/storage';
+import { WorkerLaunchPayload } from '../shared/types/events';
 
 class BackgroundService {
   private static instance: BackgroundService;
@@ -31,7 +31,8 @@ class BackgroundService {
 
     // Handle worker launch directly from content script click
     runtime.listen('player/launch_worker', async (payload, sender) => {
-      if (!sender?.tab?.id) {
+      const tabId = sender?.tab?.id;
+      if (!tabId) {
         console.info(
           '[MindStudio][Background] Worker launch failed: No tab ID',
         );
@@ -39,7 +40,6 @@ class BackgroundService {
       }
 
       try {
-        const tabId = sender.tab.id;
         // Store pending worker for this tab
         this.pendingWorkers.set(tabId, {
           ...payload,

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -38,7 +38,7 @@ export interface Events {
   'settings/open': undefined;
 
   // Sidepanel events
-  'sidepanel/ready': undefined;
+  'sidepanel/ready': { tabId: number };
 }
 
 export interface LaunchVariables {
@@ -53,6 +53,7 @@ export interface WorkerLaunchPayload {
   appName: string;
   appIcon: string;
   launchVariables: LaunchVariables;
+  tabId: number;
 }
 
 // Make event type a discriminated union based on the _MindStudioEvent field

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -1,3 +1,4 @@
+import { AppData } from './app';
 import { OrganizationData } from './organization';
 
 // Consolidate all event types in one place
@@ -26,12 +27,7 @@ export interface Events {
   // Launcher events
   'launcher/loaded': undefined;
   'launcher/apps_updated': {
-    apps: Array<{
-      id: string;
-      name: string;
-      iconUrl: string;
-      extensionSupportedSites: string[];
-    }>;
+    apps: Array<AppData>;
   };
 
   // Settings events

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -13,7 +13,7 @@ export interface Events {
 
   // Player events
   'player/loaded': void;
-  'player/launch_worker': WorkerLaunchPayload;
+  'player/launch_worker': BaseWorkerPayload;
   'player/init': WorkerLaunchPayload;
   'player/close_worker': void;
   'player/load_worker': {
@@ -48,11 +48,16 @@ export interface LaunchVariables {
   userSelection: string | null;
 }
 
-export interface WorkerLaunchPayload {
+// Base worker payload without tabId
+export interface BaseWorkerPayload {
   appId: string;
   appName: string;
   appIcon: string;
   launchVariables: LaunchVariables;
+}
+
+// Full worker payload with tabId (used internally)
+export interface WorkerLaunchPayload extends BaseWorkerPayload {
   tabId: number;
 }
 

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -12,22 +12,48 @@
         height: 100vh;
         width: 100%;
         overflow: hidden;
-        position: fixed;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          Oxygen, Ubuntu, Cantarell, sans-serif;
       }
-      #player-container {
+      .container {
         width: 100%;
         height: 100vh;
-        overflow: hidden;
-        position: fixed;
-        top: 0;
-        left: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+        box-sizing: border-box;
+        text-align: center;
+        background: #f8f9fa;
+      }
+      .logo {
+        width: 64px;
+        height: 64px;
+        margin-bottom: 24px;
+      }
+      h1 {
+        font-size: 20px;
+        margin: 0 0 12px 0;
+        color: #1a1a1a;
+      }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #666;
+        margin: 0;
+        max-width: 280px;
       }
     </style>
   </head>
   <body>
-    <div id="root">
-      <div id="player-container"></div>
+    <div class="container">
+      <img src="icons/icon128x128.png" alt="MindStudio Logo" class="logo" />
+      <h1>Welcome to MindStudio</h1>
+      <p>
+        Launch a worker from any webpage to start using MindStudio's AI
+        capabilities.
+      </p>
     </div>
-    <script src="sidepanel.js"></script>
   </body>
 </html>

--- a/src/sidepanel/index.ts
+++ b/src/sidepanel/index.ts
@@ -2,30 +2,24 @@ import { PlayerFrame } from './player-frame';
 
 class SidePanel {
   private player?: PlayerFrame;
+  private port?: chrome.runtime.Port;
 
   constructor() {
-    console.info('[MindStudio][Sidepanel] Initializing sidepanel');
+    const params = new URLSearchParams(window.location.search);
+    const tabId = params.get('tabId');
 
-    // Check if this is a worker panel via URL parameter
-    const isWorkerPanel =
-      new URLSearchParams(window.location.search).get('type') === 'worker';
+    if (tabId) {
+      // Connect to background service first
+      this.port = chrome.runtime.connect({ name: 'sidepanel' });
 
-    if (isWorkerPanel) {
       const container = document.getElementById('player-container');
       if (!container) {
         console.error('[MindStudio][Sidepanel] Player container not found');
         throw new Error('Player container not found');
       }
 
-      this.player = new PlayerFrame(container);
+      this.player = new PlayerFrame(container, parseInt(tabId, 10));
     }
-
-    this.setupConnection();
-  }
-
-  private setupConnection(): void {
-    // Connect to background service to enable messaging
-    chrome.runtime.connect({ name: 'sidepanel' });
   }
 }
 

--- a/src/sidepanel/index.ts
+++ b/src/sidepanel/index.ts
@@ -1,17 +1,25 @@
 import { PlayerFrame } from './player-frame';
 
 class SidePanel {
-  private player: PlayerFrame;
+  private player?: PlayerFrame;
 
   constructor() {
     console.info('[MindStudio][Sidepanel] Initializing sidepanel');
-    const container = document.getElementById('player-container');
-    if (!container) {
-      console.error('[MindStudio][Sidepanel] Player container not found');
-      throw new Error('Player container not found');
+
+    // Check if this is a worker panel via URL parameter
+    const isWorkerPanel =
+      new URLSearchParams(window.location.search).get('type') === 'worker';
+
+    if (isWorkerPanel) {
+      const container = document.getElementById('player-container');
+      if (!container) {
+        console.error('[MindStudio][Sidepanel] Player container not found');
+        throw new Error('Player container not found');
+      }
+
+      this.player = new PlayerFrame(container);
     }
 
-    this.player = new PlayerFrame(container);
     this.setupConnection();
   }
 

--- a/src/sidepanel/player-frame.ts
+++ b/src/sidepanel/player-frame.ts
@@ -13,7 +13,6 @@ export class PlayerFrame extends Frame {
 
   private pendingWorker: WorkerLaunchPayload | null = null;
   private isFirstLoad = true;
-  private hasLoadedFirstWorker = false;
   private tabId: number;
 
   constructor(container: HTMLElement, tabId: number) {

--- a/src/sidepanel/player-frame.ts
+++ b/src/sidepanel/player-frame.ts
@@ -14,13 +14,16 @@ export class PlayerFrame extends Frame {
   private pendingWorker: WorkerLaunchPayload | null = null;
   private isFirstLoad = true;
   private hasLoadedFirstWorker = false;
+  private tabId: number;
 
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, tabId: number) {
     super({
       id: PlayerFrame.ElementId.FRAME,
       src: `${RootUrl}/_extension/player?__displayContext=extension&__controlledAuth=1`,
       container,
     });
+
+    this.tabId = tabId;
 
     // Add frame styles
     this.element.style.cssText = `
@@ -43,7 +46,6 @@ export class PlayerFrame extends Frame {
       const organizationId = await storage.get('SELECTED_ORGANIZATION');
 
       if (token && organizationId) {
-        console.info('[MindStudio][Player] Authenticating frame');
         frame.send(PlayerFrame.ElementId.FRAME, 'auth/token_changed', {
           authToken: token,
           organizationId,
@@ -52,12 +54,13 @@ export class PlayerFrame extends Frame {
 
       // Only send ready event on first load
       if (this.isFirstLoad) {
-        await runtime.send('sidepanel/ready', undefined);
+        await runtime.send('sidepanel/ready', { tabId: this.tabId });
       }
 
       // Send any pending worker
       if (this.pendingWorker) {
-        console.info('[MindStudio][Player] Loading pending worker:', {
+        console.info('[MindStudio][Player] Loading worker:', {
+          tabId: this.tabId,
           appId: this.pendingWorker.appId,
           appName: this.pendingWorker.appName,
         });
@@ -73,7 +76,6 @@ export class PlayerFrame extends Frame {
     storage.onChange('AUTH_TOKEN', async (token) => {
       const organizationId = await storage.get('SELECTED_ORGANIZATION');
       if (organizationId && token && this.isReady()) {
-        console.info('[MindStudio][Player] Updating auth token');
         frame.send(PlayerFrame.ElementId.FRAME, 'auth/token_changed', {
           authToken: token,
           organizationId,
@@ -81,30 +83,15 @@ export class PlayerFrame extends Frame {
       }
     });
 
-    // Listen for worker launch requests
+    // Listen for worker init events
     runtime.listen('player/init', (payload: WorkerLaunchPayload) => {
-      if (!this.hasLoadedFirstWorker) {
-        // First ever worker, just store it
-        console.info('[MindStudio][Player] Initializing first worker:', {
-          appId: payload.appId,
-          appName: payload.appName,
-        });
-        this.pendingWorker = payload;
-        this.hasLoadedFirstWorker = true;
-
-        // Try to load it immediately if we're ready
+      // Only handle init events for our tab
+      if (payload.tabId === this.tabId) {
         if (this.isReady()) {
-          this.loadWorker(this.pendingWorker);
-          this.pendingWorker = null;
+          this.loadWorker(payload);
+        } else {
+          this.pendingWorker = payload;
         }
-      } else {
-        // Subsequent workers should reset frame
-        console.info('[MindStudio][Player] Switching to worker:', {
-          appId: payload.appId,
-          appName: payload.appName,
-        });
-        this.pendingWorker = payload;
-        this.reset();
       }
     });
   }

--- a/src/sidepanel/worker-panel.html
+++ b/src/sidepanel/worker-panel.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MindStudio Worker</title>
+    <style>
+      body,
+      html {
+        margin: 0;
+        padding: 0;
+        height: 100vh;
+        width: 100%;
+        overflow: hidden;
+        position: fixed;
+      }
+      #player-container {
+        width: 100%;
+        height: 100vh;
+        overflow: hidden;
+        position: fixed;
+        top: 0;
+        left: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root">
+      <div id="player-container"></div>
+    </div>
+    <script src="sidepanel.js"></script>
+  </body>
+</html>

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -55,6 +55,10 @@ module.exports = (env) => ({
           to: 'sidepanel.html',
         },
         {
+          from: './src/sidepanel/worker-panel.html',
+          to: 'worker-panel.html',
+        },
+        {
           from: './src/settings/index.html',
           to: 'settings.html',
         },


### PR DESCRIPTION
This moves the sidepanel experience from a global one to tab-specific.

New behavior:
- Global side panel that is opened pre-worker launch
- Workers are shown in side panel only on tab where it was launched