### PR TITLE
Better page context

### DIFF
--- a/src/content/launcher/index.ts
+++ b/src/content/launcher/index.ts
@@ -89,6 +89,7 @@ export class LauncherService {
       const userSelection = page.getSelectedContent();
       const rawHtml = page.cleanDOM();
       const fullText = page.getCleanTextContent();
+      const metadata = page.getMetadataBundle();
 
       await runtime.send('player/launch_worker', {
         appId: app.id,
@@ -96,6 +97,7 @@ export class LauncherService {
         appIcon: app.iconUrl,
         launchVariables: {
           url: window.location.href,
+          metadata,
           rawHtml,
           fullText,
           userSelection,

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -44,6 +44,7 @@ export interface LaunchVariables {
   url: string;
   rawHtml: string;
   fullText: string;
+  metadata: string;
   userSelection: string | null;
 }
 

--- a/src/shared/utils/page.ts
+++ b/src/shared/utils/page.ts
@@ -51,6 +51,20 @@ export const page = {
    * Gets a cleaned version of the page's text content.
    */
   getCleanTextContent(): string {
+    const selection = window.getSelection();
+    if (selection) {
+      const range = document.createRange();
+      range.selectNode(document.body);
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      const text = selection.toString(); // Extract the text
+      selection.removeAllRanges(); // Deselect after copying
+
+      return text;
+    }
+
+    // Fallback to getting the document body
     const clone = document.body.cloneNode(true) as HTMLElement;
     cleanNode(clone);
     return clone.innerText;


### PR DESCRIPTION
- Simulate "select all" (cmd + A, cmd + C) to populate the `fullText` launch variable
- Include a `metadata` launch variable with page title, description, open graph tags, and favicons