### PR TITLE
Passthrough cache events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindstudio-chrome-extension",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "engines": {
     "node": ">= 14.0.0",
     "npm": ">= 6.0.0"

--- a/src/shared/services/storage.ts
+++ b/src/shared/services/storage.ts
@@ -22,13 +22,14 @@ export type StorageValues = {
     name: string;
   }> | null;
   TOOLTIP_GUIDES_SHOWN: Record<string, boolean>;
+  REMOTE_CACHE_PREFIX: undefined;
 };
 
 // Move key generation here
 const createStorageKey = (key: string) => `${key}_${Environment}` as const;
 
 // Define storage keys
-const StorageKeys: Record<keyof StorageValues, string> = {
+export const StorageKeys: Record<keyof StorageValues, string> = {
   AUTH_TOKEN: createStorageKey('AuthToken'),
   LAUNCHER_COLLAPSED: createStorageKey('LauncherCollapsed'),
   LAUNCHER_HIDDEN: createStorageKey('LauncherHidden'),
@@ -37,6 +38,7 @@ const StorageKeys: Record<keyof StorageValues, string> = {
   SELECTED_ORGANIZATION: createStorageKey('SelectedOrganization'),
   ORGANIZATIONS: createStorageKey('Organizations'),
   TOOLTIP_GUIDES_SHOWN: createStorageKey('TooltipGuidesShown'),
+  REMOTE_CACHE_PREFIX: createStorageKey('RemoteCache'),
 } as const;
 
 export const storage = {

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -60,6 +60,21 @@ export interface Events {
 
   // Sidepanel events
   'sidepanel/toggle': undefined;
+
+  // Cache events
+  'remote/request_cache': undefined;
+  'remote/resolved_cache': {
+    cache: {
+      [index: string]: any;
+    };
+  };
+  'remote/store_cached_value': {
+    key: string;
+    value: string;
+  };
+  'remote/remove_cached_value': {
+    key: string;
+  };
 }
 
 export interface LaunchVariables {


### PR DESCRIPTION
The remote iframe in the sidepanel can not access local storage, so we use a message-based passthrough cache instead